### PR TITLE
Consistency

### DIFF
--- a/.custom_shields/process_hollowing.json
+++ b/.custom_shields/process_hollowing.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "process_hollowing",
-  "message": "1.6.0",
+  "message": "1.6.1",
   "color": "blue"
 }

--- a/.custom_shields/process_migration.json
+++ b/.custom_shields/process_migration.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "process_migration",
-  "message": "1.8.0",
+  "message": "1.8.1",
   "color": "blue"
 }

--- a/process_hollowing/Cargo.toml
+++ b/process_hollowing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process_hollowing"
-version = "1.6.0"
+version = "1.6.1"
 edition = "2021"
 authors = ["Kevin Conley <koins@duck.com>"]
 rust-version = "1.59"

--- a/process_migration/Cargo.toml
+++ b/process_migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "process_migration"
-version = "1.8.0"
+version = "1.8.1"
 edition = "2021"
 authors = ["Kevin Conley <koins@duck.com>"]
 rust-version = "1.59"


### PR DESCRIPTION
1. Remove casts `as _` where possible
2. Read memory the same way throughout the project